### PR TITLE
Use mailables for Laravel 5.3/5.4 Compatibilty

### DIFF
--- a/src/Controllers/Auth/PasswordController.php
+++ b/src/Controllers/Auth/PasswordController.php
@@ -10,6 +10,7 @@ use Sentinel;
 use App\Http\Requests;
 use Centaur\AuthManager;
 use Illuminate\Http\Request;
+use App\Mail\CentaurPasswordReset;
 use Centaur\Controllers\Controller;
 
 class PasswordController extends Controller
@@ -67,6 +68,7 @@ class PasswordController extends Controller
                         ->subject('Password Reset Link');
                 }
             );
+            Mail::to($email)->queue(new CentaurPasswordReset($email, $code));
         }
 
         $message = 'Instructions for changing your password will be sent to your email address if it is associated with a valid account.';

--- a/src/Controllers/Auth/PasswordController.php
+++ b/src/Controllers/Auth/PasswordController.php
@@ -68,7 +68,7 @@ class PasswordController extends Controller
                         ->subject('Password Reset Link');
                 }
             );
-            Mail::to($email)->queue(new CentaurPasswordReset($email, $code));
+            Mail::to($email)->queue(new CentaurPasswordReset($code));
         }
 
         $message = 'Instructions for changing your password will be sent to your email address if it is associated with a valid account.';

--- a/src/Controllers/Auth/PasswordController.php
+++ b/src/Controllers/Auth/PasswordController.php
@@ -60,14 +60,6 @@ class PasswordController extends Controller
             // Send the email
             $code = $reminder->code;
             $email = $user->email;
-            Mail::queue(
-                'centaur.email.reset',
-                ['code' => $code],
-                function ($message) use ($email) {
-                    $message->to($email)
-                        ->subject('Password Reset Link');
-                }
-            );
             Mail::to($email)->queue(new CentaurPasswordReset($code));
         }
 

--- a/src/Controllers/Auth/RegistrationController.php
+++ b/src/Controllers/Auth/RegistrationController.php
@@ -9,6 +9,7 @@ use Activation;
 use App\Http\Requests;
 use Centaur\AuthManager;
 use Illuminate\Http\Request;
+use App\Mail\CentaurWelcomeEmail;
 use Centaur\Controllers\Controller;
 
 class RegistrationController extends Controller
@@ -66,14 +67,7 @@ class RegistrationController extends Controller
         // Send the activation email
         $code = $result->activation->getCode();
         $email = $result->user->email;
-        Mail::queue(
-            'centaur.email.welcome',
-            ['code' => $code, 'email' => $email],
-            function ($message) use ($email) {
-                $message->to($email)
-                    ->subject('Your account has been created');
-            }
-        );
+        Mail::to($email)->queue(new CentaurWelcomeEmail($email, $code));
 
         // Ask the user to check their email for the activation link
         $result->setMessage('Registration complete.  Please check your email for activation instructions.');

--- a/src/Controllers/UserController.php
+++ b/src/Controllers/UserController.php
@@ -7,6 +7,7 @@ use Sentinel;
 use App\Http\Requests;
 use Centaur\AuthManager;
 use Illuminate\Http\Request;
+use App\Mail\CentaurWelcomeEmail;
 use Cartalyst\Sentinel\Users\IlluminateUserRepository;
 
 class UserController extends Controller
@@ -89,14 +90,7 @@ class UserController extends Controller
         if (!$activate) {
             $code = $result->activation->getCode();
             $email = $result->user->email;
-            Mail::queue(
-                'centaur.email.welcome',
-                ['code' => $code, 'email' => $email],
-                function ($message) use ($email) {
-                    $message->to($email)
-                        ->subject('Your account has been created');
-                }
-            );
+            Mail::to($email)->queue(new CentaurWelcomeEmail($email, $code));
         }
 
         // Assign User Roles

--- a/src/Mail/CentaurPasswordReset
+++ b/src/Mail/CentaurPasswordReset
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+class CentaurPasswordReset extends Mailable
+{
+    use Queueable, SerializesModels;
+    
+    public $code;
+    
+    /**
+     * Create a new message instance.
+     *
+     * @return void
+     */
+    public function __construct($email, $code)
+    {
+        $this->code = $code;
+    }
+
+    /**
+     * Build the message.
+     *
+     * @return $this
+     */
+    public function build()
+    {
+        return $this
+            ->subject('Password Reset Link')
+            ->view('centaur.email.reset');
+    }
+}

--- a/src/Mail/CentaurWelcomeEmail
+++ b/src/Mail/CentaurWelcomeEmail
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+class CentaurWelcomeEmail extends Mailable
+{
+    use Queueable, SerializesModels;
+    
+    public $email;
+    public $code;
+    
+    /**
+     * Create a new message instance.
+     *
+     * @return void
+     */
+    public function __construct($email, $code)
+    {
+        $this->email = $email;
+        $this->code = $code;
+    }
+
+    /**
+     * Build the message.
+     *
+     * @return $this
+     */
+    public function build()
+    {
+        return $this
+            ->subject('Your account has been created!')
+            ->view('centaur.email.welcome');
+    }
+}


### PR DESCRIPTION
Previously getting error 'only mailables can be queued' when registering new user or sending password reset email.

Two new mailables (CentaurWelcomeEmail and CentaurPasswordReset) added and UserController, RegistrationController and PasswordController updated to use mailables.