### PR TITLE
Prevent the removal of roles that have the current user as a member

### DIFF
--- a/src/Controllers/RoleController.php
+++ b/src/Controllers/RoleController.php
@@ -181,6 +181,15 @@ class RoleController extends Controller
         // $id = $this->decode($hash);
         $role = $this->roleRepository->findById($id);
 
+        // Prevent the deletion of roles have the current user as a member
+        if (Sentinel::inRole($role)) {
+            if ($request->expectsJson()) {
+                return response()->json("You must leave this group before it can be removed.", 422);
+            }
+            session()->flash('error', "You must leave this group before it can be removed.");
+            return redirect()->back()->withInput();
+        }
+
         // Remove the role
         $role->delete();
 

--- a/src/Controllers/RoleController.php
+++ b/src/Controllers/RoleController.php
@@ -2,9 +2,9 @@
 
 namespace Centaur\Controllers;
 
-use Sentinel;
 use App\Http\Requests;
 use Illuminate\Http\Request;
+use Cartalyst\Sentinel\Laravel\Facades\Sentinel;
 use Cartalyst\Sentinel\Users\IlluminateUserRepository;
 
 class RoleController extends Controller
@@ -30,8 +30,10 @@ class RoleController extends Controller
     public function index()
     {
         $roles = $this->roleRepository->createModel()->all();
+        $userRoleIds = Sentinel::getUser()->roles()->pluck('id');
 
         return view('Centaur::roles.index')
+            ->with('userRoleIds', $userRoleIds)
             ->with('roles', $roles);
     }
 

--- a/tests/Features/RoleManagementTest.php
+++ b/tests/Features/RoleManagementTest.php
@@ -139,7 +139,7 @@ class RoleManagementTest extends TestCase
     }
 
     /** @test */
-    public function you_can_remove_a_user_via_ajax()
+    public function you_can_remove_a_role_via_ajax()
     {
         // Arrange
         $role = Sentinel::findRoleByName('Subscriber');
@@ -155,5 +155,24 @@ class RoleManagementTest extends TestCase
         // Verify
         $response->assertJsonFragment(["Role 'Subscriber' has been removed."]);
         $this->assertDatabaseMissing('roles', ['name' => 'Subscriber']);
+    }
+
+    /** @test */
+    public function you_cannot_remove_roles_you_currently_belong_to()
+    {
+        // Arrange
+        $role = Sentinel::findRoleByName('Administrator');
+        $headers = [
+            'Accept' => 'application/json',
+            'X-CSRF-TOKEN' => $this->getCsrfToken(),
+        ];
+        $this->signIn('admin@admin.com');
+
+        // Act
+        $response = $this->delete('/roles/' . $role->id, [], $headers);
+
+        // Verify
+        $response->assertStatus(422);
+        $this->assertDatabaseHas('roles', ['name' => 'Administrator']);
     }
 }

--- a/views/roles/index.blade.php
+++ b/views/roles/index.blade.php
@@ -25,6 +25,7 @@
                         </tr>
                     </thead>
                     <tbody>
+                        <?php $userRoleIds = Sentinel::getUser()->roles()->pluck('id'); ?>
                         @foreach ($roles as $role)
                             <tr>
                                 <td>{{ $role->name }}</td>
@@ -35,10 +36,12 @@
                                         <span class="glyphicon glyphicon-edit" aria-hidden="true"></span>
                                         Edit
                                     </a>
+                                    @if (! $userRoleIds->contains($role->id))
                                     <a href="{{ route('roles.destroy', $role->id) }}" class="btn btn-danger" data-method="delete" data-token="{{ csrf_token() }}">
                                         <span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
                                         Delete
                                     </a>
+                                    @endif
                                 </td>
                             </tr>
                         @endforeach

--- a/views/roles/index.blade.php
+++ b/views/roles/index.blade.php
@@ -25,7 +25,6 @@
                         </tr>
                     </thead>
                     <tbody>
-                        <?php $userRoleIds = Sentinel::getUser()->roles()->pluck('id'); ?>
                         @foreach ($roles as $role)
                             <tr>
                                 <td>{{ $role->name }}</td>


### PR DESCRIPTION
There can be unexpected consequences if a user removes a role that the are an active member of.  This PR prevents that from happening. 